### PR TITLE
fix: correct period dropdown logic and add provider name to payments

### DIFF
--- a/CLAUDE_JOURNAL.md
+++ b/CLAUDE_JOURNAL.md
@@ -213,3 +213,17 @@ Key Changes:
 - Kept all scopes and permissions for Teams integration
 - Maintained single-tab configuration for simplicity
 ===============================
+
+# Fixed Applied Period Dropdown & Provider Name Display | 2025-07-07
+Description: Fixed two issues - period dropdown showing wrong periods and provider name showing as NA in payment history
+Reason: Period dropdown was skipping years and only showing ended periods; Provider name wasn't included in payment queries
+Files Touched: backend/app/api/periods.py, backend/app/api/payments.py, backend/app/models.py
+Result: Period dropdown now shows comprehensive list starting from one period prior; Provider names display correctly
+Key Changes:
+- Modified periods SQL to show periods from one period prior to current (arrears billing system)
+- For monthly: shows from previous month onwards; quarterly: from previous quarter onwards
+- If no payment history, shows 5 years back (not just current year)
+- Added provider_name to PaymentWithVariance model
+- Updated all payment queries to JOIN with contracts table for provider_name
+- Critical SQL logic: uses MONTH(GETDATE()) and CEILING(MONTH(GETDATE()) / 3.0) for period calculations
+===============================

--- a/backend/app/models.py
+++ b/backend/app/models.py
@@ -149,6 +149,7 @@ class PaymentWithVariance(Payment):
     variance_amount: Optional[float] = None
     variance_percent: Optional[float] = None
     variance_status: Literal["unknown", "exact", "acceptable", "warning", "alert"]
+    provider_name: Optional[str] = None
 
 
 class PaymentPeriod(BaseModel):


### PR DESCRIPTION
Fixes #39

## Changes

1. **Fixed Applied Period Dropdown**
   - Modified periods API to show periods starting from one period prior (arrears billing)
   - Monthly shows from previous month, quarterly from previous quarter
   - Shows 5 years of history if no payments exist

2. **Fixed Provider Name Display**
   - Added provider_name to payment responses by joining with contracts table
   - Updated PaymentWithVariance model to include provider_name field

Generated with [Claude Code](https://claude.ai/code)