### PR TITLE
docs: Update schema reference and add Python backend elimination plan

### DIFF
--- a/DB_SCHEMA_REFERENCE.txt
+++ b/DB_SCHEMA_REFERENCE.txt
@@ -1,6 +1,12 @@
 -- =====================================================
 -- Generated: 2025-07-04 13:54:07
+-- Updated: 2025-07-08 - Added critical note about soft deletes
 -- =====================================================
+
+-- CRITICAL NOTE: TODO.md claims soft deletes were eliminated but 
+-- ALL tables still have valid_to columns and ALL views still filter
+-- WHERE valid_to IS NULL. This MUST be resolved in migration.
+-- Either truly eliminate soft deletes OR update TODO.md to reflect reality.
 -- =====================================================
 -- TABLES
 -- =====================================================


### PR DESCRIPTION
Updates documentation with comprehensive migration plan for eliminating Python backend in favor of Azure Static Web Apps Database Connection.

Changes:
- Added critical note about soft delete discrepancy to DB_SCHEMA_REFERENCE.txt
- Added detailed 3-part migration gameplan to INVESTIGATION-ANALYSIS.md
- Plan written specifically for AI execution

Generated with [Claude Code](https://claude.ai/code)