### PR TITLE
fix: simplify auth to use SWA sessions for both Teams and browser

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -11,19 +11,11 @@ import Summary from './pages/Summary'
 // import Contracts from './pages/Contracts'
 import ErrorBoundary from './components/ErrorBoundary'
 import Export from './pages/Export'
-import * as microsoftTeams from '@microsoft/teams-js'
-import { isInTeams } from './teamsAuth'
 
 function AppContent() {
   const { user, loading } = useAuth();
   const dataApiClient = useDataApiClient();
   
-  // Initialize Teams SDK if in Teams context
-  useEffect(() => {
-    if (isInTeams()) {
-      microsoftTeams.app.notifySuccess();
-    }
-  }, []);
   
   // Pre-cache client list when user is authenticated
   useEffect(() => {

--- a/src/api/client.ts
+++ b/src/api/client.ts
@@ -6,7 +6,6 @@ const DATA_API_BASE = '/data-api/rest';
 // Import types
 import { Contact } from '../types/contact';
 import { apiCache, cacheKeys } from '../utils/cache';
-import { getSwaAccessToken, isInTeams } from '../teamsAuth';
 
 // Azure's standardized error format
 export interface AzureApiError {
@@ -60,25 +59,13 @@ export class DataApiClient {
     const url = `${DATA_API_BASE}/${entity}`;
     // console.log(`[DataApiClient] Requesting: ${url}`);
     
-    // Get auth headers based on context
-    const authHeaders: Record<string, string> = {};
-    if (isInTeams()) {
-      try {
-        const token = await getSwaAccessToken();
-        authHeaders['Authorization'] = `Bearer ${token}`;
-      } catch (e) {
-        console.error('Failed to get Teams token:', e);
-        // Continue without token - let SWA cookies handle it
-      }
-    }
-    
+    // Always use SWA cookie authentication
     const response = await this.requestWithRetry(url, {
       ...options,
       credentials: 'include',
       headers: {
         'Content-Type': 'application/json',
         'X-MS-API-ROLE': 'authenticated',
-        ...authHeaders,
         ...options.headers,
       },
     });


### PR DESCRIPTION
Fixes #74

This PR simplifies the authentication flow to use Azure Static Web Apps (SWA) sessions for both Teams and browser contexts.

## Problem
The app was failing in Teams due to incompatible authentication methods:
- Teams SSO provided JWT tokens
- Data API Builder (DAB) expected SWA session cookies
- This mismatch caused authentication redirect loops

## Solution
Unified authentication through SWA for all contexts:
- Both Teams and browser users now authenticate via SWA
- Removed all Teams SSO token handling
- Simplified to a single authentication flow

## Changes
- Removed Teams SSO token logic from auth flow
- Removed Bearer token handling from API client
- Cleaned up unused Teams SDK imports and functions
- Deleted obsolete auth-related files

Generated with [Claude Code](https://claude.ai/code)